### PR TITLE
Fix: Remove cypher from scripts

### DIFF
--- a/templates/backup_mysql_restic
+++ b/templates/backup_mysql_restic
@@ -6,7 +6,6 @@ set -o pipefail
 BACKUP_DIR="{{ backup__conf.local_dir }}"
 BACKUP_REPO="sftp:{{ backup__conf.restic_host }}:/home/$(hostname -s).$(hostname -d)/mysql"
 BACKUP_CONF_FILE="{{ backup__conf.local_conf }}"
-BACKUP_CYPHER="{{ backup__conf.file_cypher }}"
 
 # Si un fichier de paramètres existe, alors on le source
 [ -e "$BACKUP_CONF_FILE" ] && . "$BACKUP_CONF_FILE"

--- a/templates/backup_users_restic
+++ b/templates/backup_users_restic
@@ -5,7 +5,6 @@
 BACKUP_DIR="{{ backup__conf.local_dir }}"
 BACKUP_REPO="sftp:{{ backup__conf.restic_host }}:/home/$(hostname -s).$(hostname -d)/users"
 BACKUP_CONF_FILE="{{ backup__conf.local_conf }}"
-BACKUP_CYPHER="{{ backup__conf.file_cypher }}"
 
 # Si un fichier de paramètres existe, alors on le source
 [ -e "$BACKUP_CONF_FILE" ] && . "$BACKUP_CONF_FILE"

--- a/templates/backup_zones_restic
+++ b/templates/backup_zones_restic
@@ -5,7 +5,6 @@
 BACKUP_DIR="{{ backup__conf.local_dir }}"
 BACKUP_REPO="sftp:{{ backup__conf.restic_host }}:/home/$(hostname -s).$(hostname -d)/zones"
 BACKUP_CONF_FILE="{{ backup__conf.local_conf }}"
-BACKUP_CYPHER="{{ backup__conf.file_cypher }}"
 
 # Si un fichier de paramètres existe, alors on le source
 [ -e "$BACKUP_CONF_FILE" ] && . "$BACKUP_CONF_FILE"


### PR DESCRIPTION
Because cypher is stored elsewhere, we don't need to have it as a variable anymore.