### PR TITLE
Fix: cut paste error on restic command

### DIFF
--- a/templates/backup_cleaner_restic
+++ b/templates/backup_cleaner_restic
@@ -42,7 +42,7 @@ do
 	    [ -z "$AGE" ] && AGE=${AGE_GROUP['ALL']}
 	    real_z=$(echo $z|sed -e 's/\///;s/\//-/g')
 	    BACKUP_REPO="sftp:{{ backup__conf.restic_host }}:/home/$(hostname -s).$(hostname -d)/zones/$real_z" 
-	    restic -r $BACKUP_REPO -p /root/.restic_repo_password cat config >/dev/null 2>&1 || restic -r $BACKUP_REPO -p /root/.restic_repo_password forget --keep-within $AGE --prune >>$LOGFILE
+	    restic -r $BACKUP_REPO -p /root/.restic_repo_password forget --keep-within $AGE --prune >>$LOGFILE
 	    rc=$?
 	    if [ $rc -gt 0 ]
 	    then
@@ -53,7 +53,7 @@ do
 	done
     else
       BACKUP_REPO="sftp:{{ backup__conf.restic_host }}:/home/$(hostname -s).$(hostname -d)/$r" 
-      restic -r $BACKUP_REPO -p /root/.restic_repo_password cat config >/dev/null 2>&1 || restic -r $BACKUP_REPO -p /root/.restic_repo_password forget --keep-within $AGE --prune >>$LOGFILE
+      restic -r $BACKUP_REPO -p /root/.restic_repo_password forget --keep-within $AGE --prune >>$LOGFILE
       rc=$?
       if [ $rc -gt 0 ]
       then


### PR DESCRIPTION
The forget command is never executed due to bash syntax: ||