### PR TITLE
Fix: Parameter error on backup script

### DIFF
--- a/templates/backup_zones_restic
+++ b/templates/backup_zones_restic
@@ -22,7 +22,7 @@ fi
 
 if [ $# -ge 1 ]
 then
-    BACKUP_ZONES=$2
+    BACKUP_ZONES=$1
 fi
 
 for z in ${BACKUP_ZONES}


### PR DESCRIPTION
Wrong argument used for zone script relaunch